### PR TITLE
Consider dropping regex dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,3 @@ homepage = "https://github.com/guigui64/stybulate"
 description = "Tabulate with Style"
 categories = ["command-line-interface"]
 exclude = ["/.github/", "/scripts/"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-regex = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,7 +380,6 @@ fn create_data_line(
     str_align: &Align,
     content: &[&str],
 ) -> String {
-    let re = regex::Regex::new(r"\.0+$").unwrap();
     (row.begin.clone()
         + &(0..col_nb)
             .map(|col| {
@@ -403,12 +402,13 @@ fn create_data_line(
                     Align::Left => format!("{:<width$}", word, width = width),
                     Align::Center => format!("{:^width$}", word, width = width),
                     Align::Decimal => {
-                        let out = format!("{:>width$}", word, width = width);
-                        if let Some(mat) = re.find(&out) {
-                            out.replace(&out[mat.start()..], &" ".repeat(mat.end() - mat.start()))
-                        } else {
-                            out
+                        let mut out = format!("{:>width$}", word, width = width);
+                        if let Some(dot) = out.rfind('.') {
+                            if out[(dot + 1)..].bytes().all(|c| c == b'0') {
+                                out.replace_range(dot.., &" ".repeat(out.len() - dot));
+                            }
                         }
+                        out
                     }
                 }
             })


### PR DESCRIPTION
You don't need a regular expression just to find the decimal point in a number. You could just use `.rfind('.')` to find the decimal point.