### PR TITLE
docs.rs is the default, no need to list it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/guigui64/stybulate"
-documentation = "https://docs.rs/stybulate"
 homepage = "https://github.com/guigui64/stybulate"
 description = "Tabulate with Style"
 categories = ["command-line-interface"]


### PR DESCRIPTION
If not listed, crates.io will default to docs.rs.