### PR TITLE
Fix #14

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,7 @@ fn format_unstylable<'a>(
             .split('\n')
             .nth(line_idx)
             .expect("unstyled word can't have more \\n than styled one");
-        let width = width - (unstyled_word.len() - UnicodeWidthStr::width(&unstyled_word as &str));
+        let width = width - (UnicodeWidthStr::width(&unstyled_word as &str) - unstyled_word.chars().count());
         let formatted = match align {
             Align::Right => format!("{:>width$}", unstyled_word, width = width),
             Align::Left => format!("{:<width$}", unstyled_word, width = width),
@@ -771,6 +771,26 @@ mod tests {
             "+---------------------------------------------------------+---------+",
             "| pi                                                      |  3.1415 |",
             "+---------------------------------------------------------+---------+",
+        ]
+        .join("\n");
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn issue_14() {
+        let headers = Headers::from(vec!["Hello", "World"]);
+        let contents = vec![vec![
+            Cell::from("✔"),
+            Cell::from("foo"),
+        ]];
+
+        let result = Table::new(Style::Grid, contents, Some(headers)).tabulate();
+        let expected = vec![
+            "+---------+---------+",
+            "| Hello   | World   |",
+            "+=========+=========+",
+            "| ✔       | foo     |",
+            "+---------+---------+",
         ]
         .join("\n");
         assert_eq!(expected, result);


### PR DESCRIPTION
The key is to switch from unstyled_words.len() to unstyled_words.chars().count() in order to be consistent with how format!() computes widths.

Fixes #14.